### PR TITLE
Various Features

### DIFF
--- a/example/lib/general_entities/fullname.dart
+++ b/example/lib/general_entities/fullname.dart
@@ -1,5 +1,4 @@
 import 'package:example/value_objects.dart/name.dart';
-import 'package:flutter/rendering.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:modddels_annotations/modddels_annotations.dart';
 import 'package:fpdart/fpdart.dart';
@@ -12,7 +11,7 @@ class FullName extends GeneralEntity<FullNameGeneralFailure, InvalidFullName,
     ValidFullName> with $FullName {
   factory FullName({
     required Name firstName,
-    @InvalidNull('const FullNameGeneralFailure.incomplete()')
+    @NullFailure('const FullNameGeneralFailure.incomplete()')
     @withGetter
         required Name? lastName,
     @validWithGetter bool hasMiddleName = false,
@@ -40,20 +39,4 @@ class FullNameGeneralFailure extends GeneralFailure
     with _$FullNameGeneralFailure {
   const factory FullNameGeneralFailure.tooLong() = _TooLong;
   const factory FullNameGeneralFailure.incomplete() = _Incomplete;
-}
-
-class Heh extends InvalidValueObject<String, NameValueFailure> {
-  Heh(this.valueFailure);
-
-  @override
-  final NameValueFailure valueFailure;
-
-  @override
-  Failure get failure => valueFailure;
-
-  @override
-  List<Object?> get props => [valueFailure];
-
-  @override
-  StringifyMode get stringifyMode => StringifyMode.always;
 }

--- a/example/lib/general_entities/fullname.g.dart
+++ b/example/lib/general_entities/fullname.g.dart
@@ -6,6 +6,8 @@ part of 'fullname.dart';
 // ModddelGenerator
 // **************************************************************************
 
+// ignore_for_file: prefer_void_to_null
+
 mixin $FullName {
   static FullName _create({
     required Name firstName,
@@ -65,7 +67,7 @@ mixin $FullName {
   }
 
   /// This holds a [GeneralFailure] on the Left if :
-  ///  - One of the nullable fields marked with `@InvalidNull` is null
+  ///  - One of the nullable fields marked with `@NullFailure` is null
   ///  - The validateGeneral method returns a [GeneralFailure]
   /// Otherwise, holds the ValidEntity on the Right.
   static Either<FullNameGeneralFailure, ValidFullName> _verifyGeneral(
@@ -81,15 +83,9 @@ mixin $FullName {
     return generalVerification;
   }
 
-  Name? get lastName => mapValidity(
-        valid: (valid) => valid.lastName,
-        invalid: (invalid) => invalid.lastName,
-      );
+  Name? get lastName => throw UnimplementedError();
 
-  bool get hasMiddleName => mapValidity(
-        valid: (valid) => valid.hasMiddleName,
-        invalid: (invalid) => invalid.hasMiddleName,
-      );
+  bool get hasMiddleName => throw UnimplementedError();
 
   /// If [nullableEntity] is null, returns `right(null)`.
   /// Otherwise, returns `nullableEntity.toBroadEither`.
@@ -178,7 +174,7 @@ class _ValidFullNameContent {
   final ValidName? lastName;
   final bool hasMiddleName;
 
-  /// If one of the nullable fields marked with `@InvalidNull` is null, this
+  /// If one of the nullable fields marked with `@NullFailure` is null, this
   /// holds a [GeneralFailure] on the Left. Otherwise, holds the ValidEntity on
   /// the Right.
   Either<FullNameGeneralFailure, ValidFullName> verifyNullables() {

--- a/example/lib/simple_entities/fullname2.g.dart
+++ b/example/lib/simple_entities/fullname2.g.dart
@@ -6,6 +6,8 @@ part of 'fullname2.dart';
 // ModddelGenerator
 // **************************************************************************
 
+// ignore_for_file: prefer_void_to_null
+
 mixin $FullName2 {
   static FullName2 _create({
     required Name firstName,

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -163,7 +163,7 @@ packages:
     source: hosted
     version: "2.2.2"
   equatable:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: equatable
       url: "https://pub.dartlang.org"

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -10,6 +10,7 @@ environment:
 
 dependencies:
   cupertino_icons: ^1.0.4
+  equatable: ^2.0.3
   flutter:
     sdk: flutter
   fpdart: ^0.0.14

--- a/modddels_annotations/README.md
+++ b/modddels_annotations/README.md
@@ -1,21 +1,21 @@
-<!-- 
+<!--
 This README describes the package. If you publish this package to pub.dev,
 this README's contents appear on the landing page for your package.
 
 For information about how to write a good package README, see the guide for
-[writing package pages](https://dart.dev/guides/libraries/writing-package-pages). 
+[writing package pages](https://dart.dev/guides/libraries/writing-package-pages).
 
 For general information about developing packages, see the Dart guide for
 [creating packages](https://dart.dev/guides/libraries/create-library-packages)
 and the Flutter guide for
-[developing packages and plugins](https://flutter.dev/developing-packages). 
+[developing packages and plugins](https://flutter.dev/developing-packages).
 -->
 
 # Intro
 
-Modddels are "validated" objects that can have two states : *Valid* or *Invalid*.
+Modddels are "validated" objects that can have two states : _Valid_ or _Invalid_.
 
-Depending on the modddel, there are different types of validations, which are run in a specific order. If all the validations pass, then the modddel is *Valid*. Otherwise, it is *Invalid* and holds a failure. The *Invalid* state is further subdivided into multiple states, each one corresponding to a failed validation.
+Depending on the modddel, there are different types of validations, which are run in a specific order. If all the validations pass, then the modddel is _Valid_. Otherwise, it is _Invalid_ and holds a failure. The _Invalid_ state is further subdivided into multiple states, each one corresponding to a failed validation.
 
 The different states a Modddel can have are represented with **Union Cases Classes**. This allows to deal with the different states of the Modddel in a compile-safe way, making impossible states impossible.
 
@@ -31,7 +31,9 @@ The different states a Modddel can have are represented with **Union Cases Class
 		- [NullableValueObject](#nullablevalueobject)
 	- [SimpleEntity](#simpleentity)
 		- [Usage](#usage-1)
-		- [The valid annotation](#the-valid-annotation)
+		- [Nullable parameters](#nullable-parameters)
+		- [The `valid` annotation](#the-valid-annotation)
+		- [The `invalid` annotation](#the-invalid-annotation)
 	- [ListEntity](#listentity)
 		- [Usage](#usage-2)
 	- [SizedListEntity](#sizedlistentity)
@@ -40,6 +42,7 @@ The different states a Modddel can have are represented with **Union Cases Class
 		- [Usage](#usage-4)
 		- [Fields getters](#fields-getters)
 		- [The `valid` annotation](#the-valid-annotation-1)
+		- [The `invalid` annotation](#the-invalid-annotation-1)
 		- [The `InvalidNull` annotation](#the-invalidnull-annotation)
 	- [ListGeneralEntity](#listgeneralentity)
 		- [Usage](#usage-5)
@@ -48,8 +51,10 @@ The different states a Modddel can have are represented with **Union Cases Class
 	- [Additionnal remarks](#additionnal-remarks)
 		- [TypeName annotation](#typename-annotation)
 		- [Optional and Nullable types](#optional-and-nullable-types)
-		- [Modddels that are always valid](#modddels-that-are-always-valid)
 		- [List getter](#list-getter)
+	- [Special cases](#special-cases)
+		- [Modddels that are always valid](#modddels-that-are-always-valid)
+		- [Modddels that are always invalid](#modddels-that-are-always-invalid)
 - [Testers](#testers)
 - [VsCode snippets](#vscode-snippets)
 - [Additional information](#additional-information)
@@ -86,58 +91,58 @@ When creating the ValueObject, the validation is made in this order :
 
 1. **Value Validation** : If the value is invalid, this ValueObject becomes an `InvalidValueObject` that holds the `ValueFailure`.
 2. **→ Validations passed** : This ValueObject is valid, and becomes a `ValidValueObject`.
-  
+
 ### Usage
 
 1. Create a ValueObject, and annotate it with `@modddel`
 
-	```dart
-	@modddel
-	class Name extends ValueObject<String, NameValueFailure, InvalidName, ValidName>
-		with $Name {
-	factory Name(String input) {
-		return $Name._create(input);
-	}
+   ```dart
+   @modddel
+   class Name extends ValueObject<String, NameValueFailure, InvalidName, ValidName>
+   	with $Name {
+   factory Name(String input) {
+   	return $Name._create(input);
+   }
 
-	const Name._();
+   const Name._();
 
-	@override
-	Option<NameValueFailure> validateValue(String input) {
-		// TODO: implement validateValue
-		return none();
-	}
-	}
-	```
+   @override
+   Option<NameValueFailure> validateValue(String input) {
+   	// TODO: implement validateValue
+   	return none();
+   }
+   }
+   ```
 
 2. Create a Freezed ValueFailure for your ValueObject
 
-	```dart
-	@freezed
-	class NameValueFailure extends ValueFailure<String> with _$NameValueFailure {
-	const factory NameValueFailure.empty({
-		required String failedValue,
-	}) = _Empty;
-	}
-	```
+   ```dart
+   @freezed
+   class NameValueFailure extends ValueFailure<String> with _$NameValueFailure {
+   const factory NameValueFailure.empty({
+   	required String failedValue,
+   }) = _Empty;
+   }
+   ```
 
 3. Add the part statements
 
-	```dart
-	part 'name.g.dart';
-	part 'name.freezed.dart';
-	```
+   ```dart
+   part 'name.g.dart';
+   part 'name.freezed.dart';
+   ```
 
 4. Implement the `validateValue` method :
 
-	```dart
-	@override
-	Option<NameValueFailure> validateValue(String input) {
-		if (input.isEmpty) {
-			return some(NameValueFailure.empty(failedValue: input));
-		}
-		return none();
-	}
-	```
+   ```dart
+   @override
+   Option<NameValueFailure> validateValue(String input) {
+   	if (input.isEmpty) {
+   		return some(NameValueFailure.empty(failedValue: input));
+   	}
+   	return none();
+   }
+   ```
 
 5. Run the generator
 
@@ -179,7 +184,7 @@ class Name2ValueFailure extends ValueFailure<String?> with _$Name2ValueFailure {
 
 Here, if the value is null, then the ValueObject will be an `InvalidValueObject` with a value failure `Name2ValueFailure.none`.
 
->**NB :** This null verification is done just before the `validateValue` method is called. So the value passed in the `validateValue` method will be non-nullable.
+> **NB :** This null verification is done just before the `validateValue` method is called. So the value passed in the `validateValue` method will be non-nullable.
 
 ---
 
@@ -196,32 +201,38 @@ When creating a SimpleEntity, the validation is made in this order :
 
 1. Create a SimpleEntity, and annotate it with `@modddel`
 
-	```dart
-	@modddel
-	class FullName extends SimpleEntity<InvalidFullNameContent, ValidFullName> with $FullName {
-	factory FullName({
-		required Name firstName,
-		required Name lastName,
-	}) {
-		return $FullName._create(
-		firstName: firstName,
-		lastName: lastName,
-		);
-	}
+   ```dart
+   @modddel
+   class FullName extends SimpleEntity<InvalidFullNameContent, ValidFullName> with $FullName {
+   factory FullName({
+   	required Name firstName,
+   	required Name lastName,
+   }) {
+   	return $FullName._create(
+   	firstName: firstName,
+   	lastName: lastName,
+   	);
+   }
 
-	const FullName._();
-	}
-	```
+   const FullName._();
+   }
+   ```
 
 2. Add the part statement
 
-	```dart
-	part 'fullname.g.dart';
-	```
+   ```dart
+   part 'fullname.g.dart';
+   ```
 
 3. Run the generator
 
-### The valid annotation
+### Nullable parameters
+
+When a `SimpleEntity` contains a nullable modddel, when it is null, it is considered valid during the "Content Validation" step.
+
+If you want a nullable modddel to make the Entity invalid when it's null, consider using a `GeneralEntity` and annotating the parameter with the [`@InvalidNull` annotation.](#the-invalidnull-annotation)
+
+### The `valid` annotation
 
 Sometimes, you want a `SimpleEntity` to contain a modddel that is always valid, or a parameter that isn't a modddel and that should considered as being valid. For example : a ValidValueObject, a ValidEntity, a boolean...
 
@@ -234,6 +245,30 @@ factory FullName({
     @valid required bool hasMiddleName,
   }) { ...
 ```
+
+> **NB :** The parameters of a `SimpleEntity` can't all be annotated with `@valid`. That's because it would mean the Entity would always be valid, while fundamentally, an Entity can either be valid or invalid.
+>
+> For an alternative to this specific case, see [the related section in "Special Cases".](#modddels-that-are-always-valid)
+
+### The `invalid` annotation
+
+Sometimes, you want a `SimpleEntity` to contain a modddel that is always invalid, unless it is null. For example : an InvalidValueObject, an InvalidEntity...
+
+In that case, you can annotate it with `@invalid`. Example :
+
+```dart
+factory FullName({
+    required Name firstName,
+    required Name lastName,
+    @invalid @TypeName('InvalidName?') required InvalidName? middleName,
+  }) { ...
+```
+
+> **NB :** The `invalid` annotation can only be used on nullable parameters. That 's because, as mentioned before, null parameters are considered valid. So a nullable parameter annotated with `@invalid` would be considered valid when it's null, and invalid when it isn't.
+>
+> On the other hand, a non-nullable parameter annotated with `@invalid` would always be considered invalid, which would mean the Entity would always be invalid, while fundamentally, an Entity can either be valid or invalid.
+>
+> For an alternative to this specific case, see [the related section in "Special Cases".](#modddels-that-are-always-invalid)
 
 ## ListEntity
 
@@ -250,22 +285,22 @@ When creating a ListEntity, the validation is made in this order :
 
 1. Create a ListEntity, and annotate it with `@modddel`
 
-	```dart
-	@modddel
-	class NameList extends ListEntity<InvalidNameListContent, ValidNameList> with $NameList {
-		factory NameList(KtList<Name> list) {
-			return $NameList._create(list);
-		}
+   ```dart
+   @modddel
+   class NameList extends ListEntity<InvalidNameListContent, ValidNameList> with $NameList {
+   	factory NameList(KtList<Name> list) {
+   		return $NameList._create(list);
+   	}
 
-		const NameList._();
-	}
-	```
+   	const NameList._();
+   }
+   ```
 
 2. Add the part statement
 
-	```dart
-	part 'namelist.g.dart';
-	```
+   ```dart
+   part 'namelist.g.dart';
+   ```
 
 3. Run the generator
 
@@ -283,50 +318,50 @@ When creating a SizedListEntity, the validation is made in this order :
 
 1. Create a SizedListEntity, and annotate it with `@modddel`
 
-	```dart
-	@modddel
-	class NameList extends SizedListEntity<NameListSizeFailure,InvalidNameList, ValidNameList> with $NameList {
-		factory NameList(KtList<Name> list) {
-			return $NameList._create(list);
-		}
+   ```dart
+   @modddel
+   class NameList extends SizedListEntity<NameListSizeFailure,InvalidNameList, ValidNameList> with $NameList {
+   	factory NameList(KtList<Name> list) {
+   		return $NameList._create(list);
+   	}
 
-		const NameList._();
+   	const NameList._();
 
-		@override
-		Option<NameListSizeFailure> validateSize(int listSize) {
-			//TODO Implement validateSize
-			return none();
-		}
-	}
-	```
+   	@override
+   	Option<NameListSizeFailure> validateSize(int listSize) {
+   		//TODO Implement validateSize
+   		return none();
+   	}
+   }
+   ```
 
 2. Create a Freezed SizeFailure for your entity
 
-	```dart
-	@freezed
-	class NameListSizeFailure extends SizeFailure with _$NameListSizeFailure {
-		const factory NameListSizeFailure.empty() = _Empty;
-	}
-	```
+   ```dart
+   @freezed
+   class NameListSizeFailure extends SizeFailure with _$NameListSizeFailure {
+   	const factory NameListSizeFailure.empty() = _Empty;
+   }
+   ```
 
 3. Add the part statements
 
-	```dart
-	part 'namelist.g.dart';
-	part 'namelist.freezed.dart';
-	```
+   ```dart
+   part 'namelist.g.dart';
+   part 'namelist.freezed.dart';
+   ```
 
 4. Implement the `validateSize` method :
 
-	```dart
-	@override
-	Option<NameListSizeFailure> validateSize(int listSize) {
-		if (listSize == 0) {
-		return some(const NameListSizeFailure.empty());
-		}
-		return none();
-	}
-	```
+   ```dart
+   @override
+   Option<NameListSizeFailure> validateSize(int listSize) {
+   	if (listSize == 0) {
+   	return some(const NameListSizeFailure.empty());
+   	}
+   	return none();
+   }
+   ```
 
 5. Run the generator
 
@@ -346,57 +381,57 @@ When creating a GeneralEntity, the validation is made in this order :
 
 1. Create a General Entity, and annotate it with `@modddel`
 
-	```dart
-	@modddel
-	class FullName extends GeneralEntity<FullNameGeneralFailure, InvalidFullNameGeneral,
-		InvalidFullNameContent, InvalidFullName, ValidFullName> with $FullName {
-	factory FullName({
-		required Name firstName,
-		required Name lastName,
-	}) {
-		return $FullName._create(
-		firstName: firstName,
-		lastName: lastName,
-		);
-	}
+   ```dart
+   @modddel
+   class FullName extends GeneralEntity<FullNameGeneralFailure, InvalidFullNameGeneral,
+   	InvalidFullNameContent, InvalidFullName, ValidFullName> with $FullName {
+   factory FullName({
+   	required Name firstName,
+   	required Name lastName,
+   }) {
+   	return $FullName._create(
+   	firstName: firstName,
+   	lastName: lastName,
+   	);
+   }
 
-	const FullName._();
+   const FullName._();
 
-	@override
-	Option<FullNameGeneralFailure> validateGeneral(ValidFullName valid) {
-		// TODO: implement validateGeneral
-		return none();
-	}
-	}
-	```
+   @override
+   Option<FullNameGeneralFailure> validateGeneral(ValidFullName valid) {
+   	// TODO: implement validateGeneral
+   	return none();
+   }
+   }
+   ```
 
 2. Create a Freezed GeneralFailure for your entity
 
-	```dart
-	@freezed
-	class FullNameGeneralFailure extends GeneralFailure with _$FullNameGeneralFailure {
-	const factory FullNameGeneralFailure.tooLong() = _TooLong;
-	}
-	```
+   ```dart
+   @freezed
+   class FullNameGeneralFailure extends GeneralFailure with _$FullNameGeneralFailure {
+   const factory FullNameGeneralFailure.tooLong() = _TooLong;
+   }
+   ```
 
 3. Add the part statements
 
-	```dart
-	part 'fullname.g.dart';
-	part 'fullname.freezed.dart';
-	```
+   ```dart
+   part 'fullname.g.dart';
+   part 'fullname.freezed.dart';
+   ```
 
 4. Implement the `validateGeneral` method :
 
-	```dart
-	@override
-	Option<FullNameGeneralFailure> validateGeneral(ValidFullName valid) {
-		if (valid.firstName.value.length + valid.lastName.value.length > 30) {
-		return some(const FullNameGeneralFailure.tooLong());
-		}
-		return none();
-	}
-	```
+   ```dart
+   @override
+   Option<FullNameGeneralFailure> validateGeneral(ValidFullName valid) {
+   	if (valid.firstName.value.length + valid.lastName.value.length > 30) {
+   	return some(const FullNameGeneralFailure.tooLong());
+   	}
+   	return none();
+   }
+   ```
 
 5. Run the generator
 
@@ -418,7 +453,7 @@ For example :
 
 That's because the GeneralEntity may have a `GeneralFailure`, which otherwise may be unnoticed by you the developer.
 
-Nonetheless, if you want to have a direct getter for a field from the unvalidated GeneralEntity, you can use the @withGetter annotation.
+Nonetheless, if you want to have a direct getter for a field from the unvalidated GeneralEntity, you can use the `@withGetter` annotation.
 A good usecase for this would be for an "id" field.
 
 ### The `valid` annotation
@@ -427,9 +462,24 @@ You can use the `@valid` annotation as you would with a `SimpleEntity`.
 
 If you want to use both `@valid` and `@withGetter` annotation, you can use the shorthand `@validWithGetter` annotation.
 
+> **NB :** The parameters of a `GeneralEntity` can't all be annotated with `@valid`. That's because it would mean the `GeneralEntity` will never be an `InvalidEntityContent`, while the code won't reflect that. This would violate the principle of making impossible states impossible.
+>
+> For an alternative to this specific case, see #TODO
+
+### The `invalid` annotation
+
+You can use the `@invalid` annotation as you would with a `SimpleEntity`.
+
+If you want to use both `@invalid` and `@withGetter` annotation, you can use the shorthand `@invalidWithGetter` annotation.
+
+> **NB :** For the same reasons as for `SimpleEntity` [(mentioned here)](#the-invalid-annotation), the `invalid` annotation can only be used on nullable parameters.
+
 ### The `InvalidNull` annotation
 
-If your entity contains a nullable modddel that you want to be non-nullable in the `ValidEntity`, then you should use the `@InvalidNull` annotation.
+When a `GeneralEntity` contains a nullable modddel, when it is null, it is considered valid during the "Content Validation" step. If you want the `GeneralEntity` to be invalid when that parameter is null, you could :
+
+- Verify if the parameter is null in the `validateGeneral` method, and if so, return a `GeneralFailure`. **(Not recommended)**
+- Use the `@InvalidNull` annotation with the String of the `GeneralFailure`. This is the recommended way, since it has the benefit of making the field non-nullable in the `ValidEntity`.
 
 Example :
 
@@ -445,11 +495,13 @@ class FullName extends GeneralEntity<FullNameGeneralFailure, InvalidFullName,
 
 ```
 
-Here, if the field `lastName` is null, then the FullName entity will be an `InvalidEntityGeneral`, with as a general failure `FullNameGeneralFailure.incomplete()`.
+Here, if the field `lastName` is null, then the `FullName` entity will be an `InvalidEntityGeneral`, with as a general failure `FullNameGeneralFailure.incomplete()`. The field `lastName` in `ValidFullName` is non-nullable.
 
->**NB :** This validation step of nullable fields marked with the `@InvalidNull` annotation occurs just before the `validateGeneral` method is called. So the entity passed in the `validateGeneral` method will have those fields non-nullable.
+> **NB 1:** This validation step of nullable fields marked with the `@InvalidNull` annotation occurs just before the `validateGeneral` method is called. So the entity passed in the `validateGeneral` method will have those fields non-nullable.
 >
->**NB :** You can use the `@InvalidNull` annotation with any other annotation.
+> **NB 2:** The `@InvalidNull` annotation can be used with any other annotation, except `@invalid`. That's because a nullable parameter annotated with both `@invalid` and `@InvalidNull` will cause the `GeneralEntity` to never be valid, while fundamentally, an Entity can either be valid or invalid.
+>
+> For an alternative to this specific case, see [the related section in "Special Cases".](#modddels-that-are-always-invalid).
 
 ## ListGeneralEntity
 
@@ -465,52 +517,52 @@ When creating a ListGeneralEntity, the validation is made in this order :
 
 1. Create a ListGeneralEntity, and annotate it with `@modddel`
 
-	```dart
-	@modddel
-	class NameList extends ListGeneralEntity<NameListGeneralFailure,
-		InvalidNameList, ValidNameList> with $NameList {
-		factory NameList(KtList<Name> list) {
-			return $NameList._create(list);
-		}
+   ```dart
+   @modddel
+   class NameList extends ListGeneralEntity<NameListGeneralFailure,
+   	InvalidNameList, ValidNameList> with $NameList {
+   	factory NameList(KtList<Name> list) {
+   		return $NameList._create(list);
+   	}
 
-		const NameList._();
+   	const NameList._();
 
-		@override
-		Option<NameListGeneralFailure> validateGeneral(ValidNameList valid) {
-			//TODO Implement validateGeneral
-			return none();
-		}
-	}
-	```
+   	@override
+   	Option<NameListGeneralFailure> validateGeneral(ValidNameList valid) {
+   		//TODO Implement validateGeneral
+   		return none();
+   	}
+   }
+   ```
 
 2. Create a Freezed GeneralFailure for your entity
 
-	```dart
-	@freezed
-	class NameListGeneralFailure extends GeneralFailure
-		with _$NameListGeneralFailure {
-	const factory NameListGeneralFailure.duplicateName() = _DuplicateName;
-	}
-	```
+   ```dart
+   @freezed
+   class NameListGeneralFailure extends GeneralFailure
+   	with _$NameListGeneralFailure {
+   const factory NameListGeneralFailure.duplicateName() = _DuplicateName;
+   }
+   ```
 
 3. Add the part statements
 
-	```dart
-	part 'namelist.g.dart';
-	part 'namelist.freezed.dart';
-	```
+   ```dart
+   part 'namelist.g.dart';
+   part 'namelist.freezed.dart';
+   ```
 
 4. Implement the `validateGeneral` method :
 
-	```dart
-	@override
-	Option<NameListGeneralFailure> validateGeneral(ValidNameList valid) {
-		if (valid.list.distinct().size != valid.size) {
-			return some(const NameListGeneralFailure.duplicateName());
-		}
-		return none();
-	}
-	```
+   ```dart
+   @override
+   Option<NameListGeneralFailure> validateGeneral(ValidNameList valid) {
+   	if (valid.list.distinct().size != valid.size) {
+   		return some(const NameListGeneralFailure.duplicateName());
+   	}
+   	return none();
+   }
+   ```
 
 5. Run the generator
 
@@ -533,79 +585,79 @@ When creating a SizedListGeneralEntity, the validation is made in this order :
 
 1. Create a SizedListGeneralEntity, and annotate it with `@modddel`
 
-	```dart
-	@modddel
-	class NameList extends SizedListGeneralEntity<NameListSizeFailure, NameListGeneralFailure,
-	InvalidNameList, ValidNameList> with $NameList {
-		factory NameList(KtList<> list) {
-			return $NameList._create(list);
-		}
+   ```dart
+   @modddel
+   class NameList extends SizedListGeneralEntity<NameListSizeFailure, NameListGeneralFailure,
+   InvalidNameList, ValidNameList> with $NameList {
+   	factory NameList(KtList<> list) {
+   		return $NameList._create(list);
+   	}
 
-		const NameList._();
+   	const NameList._();
 
-		@override
-		Option<NameListSizeFailure> validateSize(int listSize) {
-			//TODO Implement validateSize
-			return none();
-		}
+   	@override
+   	Option<NameListSizeFailure> validateSize(int listSize) {
+   		//TODO Implement validateSize
+   		return none();
+   	}
 
-		@override
-		Option<NameListGeneralFailure> validateGeneral(ValidNameList valid) {
-			//TODO Implement validateGeneral
-			return none();
-		}
-	}
-	```
+   	@override
+   	Option<NameListGeneralFailure> validateGeneral(ValidNameList valid) {
+   		//TODO Implement validateGeneral
+   		return none();
+   	}
+   }
+   ```
 
 2. Create a Freezed SizeFailure for your entity
 
-	```dart
-	@freezed
-	class NameListSizeFailure extends SizeFailure with _$NameListSizeFailure {
-		const factory NameListSizeFailure.empty() = _Empty;
-	}
-	```
+   ```dart
+   @freezed
+   class NameListSizeFailure extends SizeFailure with _$NameListSizeFailure {
+   	const factory NameListSizeFailure.empty() = _Empty;
+   }
+   ```
 
 3. Create a Freezed GeneralFailure for your entity
 
-	```dart
-	@freezed
-	class NameListGeneralFailure extends GeneralFailure
-		with _$NameListGeneralFailure {
-	const factory NameListGeneralFailure.duplicateName() = _DuplicateName;
-	}
-	```
+   ```dart
+   @freezed
+   class NameListGeneralFailure extends GeneralFailure
+   	with _$NameListGeneralFailure {
+   const factory NameListGeneralFailure.duplicateName() = _DuplicateName;
+   }
+   ```
 
 4. Add the part statements
 
-	```dart
-	part 'namelist.g.dart';
-	part 'namelist.freezed.dart';
-	```
+   ```dart
+   part 'namelist.g.dart';
+   part 'namelist.freezed.dart';
+   ```
 
 5. Implement the `validateSize` method :
 
-	```dart
-	@override
-	Option<NameListSizeFailure> validateSize(int listSize) {
-		if (listSize == 0) {
-			return some(const NameListSizeFailure.empty());
-		}
-		return none();
-	}
-	```
+   ```dart
+   @override
+   Option<NameListSizeFailure> validateSize(int listSize) {
+   	if (listSize == 0) {
+   		return some(const NameListSizeFailure.empty());
+   	}
+   	return none();
+   }
+   ```
 
 6. Implement the `validateGeneral` method :
 
-	```dart
-	@override
-	Option<NameListGeneralFailure> validateGeneral(ValidNameList valid) {
-		if (valid.list.distinct().size != valid.size) {
-			return some(const NameListGeneralFailure.duplicateName());
-		}
-		return none();
-	}
-	```
+   ```dart
+   @override
+   Option<NameListGeneralFailure> validateGeneral(ValidNameList valid) {
+   	if (valid.list.distinct().size != valid.size) {
+   		return some(const NameListGeneralFailure.duplicateName());
+   	}
+   	return none();
+   }
+   ```
 
 7. Run the generator
 
@@ -643,12 +695,6 @@ Here, `ValidName` is a generated class so it's not defined during the generation
 
 `SimpleEntity` and `GeneralEntity` both support containing optional and nullable parameters, as well as default values.
 
-### Modddels that are always valid
-
-You can create a ValidValueObject or a ValidEntity by directly extending respectively the class `ValidValueObject` or `ValidEntity`.
-
-When using them as parameters inside a `SimpleEntity` or `GeneralEntity`, don't forget to annotate them with `@valid`.
-
 ### List getter
 
 Unlike a ListEntity, ListGeneralEntity, SizedListEntity, and SizedListGeneralEntity hide the list inside `ValidEntity` and `InvalidEntity`, so you can only access it after calling the "mapValidity" method (or other pattern matching methods).
@@ -667,6 +713,155 @@ For example :
 
 That's because the entity may have a `GeneralFailure` or a `SizeFailure`, which otherwise may be unnoticed by you the developer.
 
+## Special cases
+
+There are a few special cases that you might encounter.
+
+### Modddels that are always valid
+
+Sometimes you may want to create a modddel that is always valid. For example :
+
+- A `ValueObject` that is always valid and doesn't need validation
+- A `SimpleEntity` with only `@valid` parameters [(See remark)](#the-valid-annotation)
+
+However, modddels by definition have both a valid and invalid state, so this isn't allowed.
+
+**Alternative :**
+
+Create a dataclass and extend one of these classes :
+
+- `ValidValueObject`
+- `ValidEntity`
+
+When using the dataclass as a parameter inside a `SimpleEntity` or `GeneralEntity`, don't forget to annotate the parameter with `@valid`.
+
+_Example 1 :_ Creating a `ValidEntity` using freezed
+
+```dart
+@freezed
+class ValidPerson1 extends ValidEntity with _$ValidPerson1 {
+  const factory ValidPerson1({
+    required int age,
+    required String name,
+  }) = _ValidPerson1;
+}
+```
+
+_Example 2 :_ Creating a `ValidEntity` using Equatable
+
+```dart
+class ValidPerson2 extends ValidEntity with EquatableMixin, Stringify {
+  const ValidPerson2({required this.age, required this.name});
+
+  final int age;
+  final String name;
+
+  @override
+  List<Object?> get props => [age, name];
+
+  @override
+  StringifyMode get stringifyMode => StringifyMode.always;
+}
+```
+
+> **NB :** While extending `ValidEntity` or `ValidValueObject` doesn't offer any extra functionality to these dataclasses, it is a good practice to do so because it makes your code and intentions clear. It is also a good practice to start the names of these dataclasses with `"Valid"`.
+
+### Modddels that are always invalid
+
+Sometimes you may need to create a modddel that is always invalid. For example :
+
+- A ValueObject that is always invalid and holds a Failure.
+- A `SimpleEntity` or `GeneralEntity` with a non-nullable `@invalid` parameter [(See remark)](#the-invalid-annotation)
+- A `GeneralEntity` with a nullable parameter annotated with both `@invalid` and `@InvalidNull` [(See remark)](#the-invalidnull-annotation)
+
+However, modddels by definition have both a valid and invalid state, so this isn't allowed.
+
+**Alternative :**
+
+Create a dataclass and extend one of these classes :
+
+- `InvalidValueObject`
+- `InvalidEntity`
+- `InvalidEntityContent`
+- `InvalidEntityGeneral`
+- `InvalidEntitySize`
+
+Then override the proper `failure` method.
+
+When using the dataclass as a parameter inside a `SimpleEntity` or `GeneralEntity`, don't forget to annotate the parameter with `@invalid`.
+
+> **NB :** It is a good practice to start the name of the dataclass with `"Invalid"`.
+
+_Example 1 :_ Creating an `InvalidEntityContent` using freezed. This also demonstrates the alternative for the situation where we want to have a non-nullable `@invalid` parameter (`invalidName`).
+
+```dart
+@freezed
+class InvalidPersonContent1 extends InvalidEntityContent
+    with _$InvalidPersonContent1 {
+  const factory InvalidPersonContent1({
+    required Age age,
+    required InvalidName invalidName,
+  }) = _InvalidPersonContent1;
+
+  const InvalidPersonContent1._();
+
+  @override
+  Failure get contentFailure => invalidName.failure;
+}
+```
+
+There's no need to verify other fields since `invalidName` will be always invalid.
+
+_Example 2 :_ Same example, this time using Equatable.
+
+```dart
+class InvalidPersonContent2 extends InvalidEntityContent
+    with EquatableMixin, Stringify {
+  InvalidPersonContent2(this.age, this.invalidName);
+
+  final Age age;
+  final InvalidName invalidName;
+
+  @override
+  Failure get contentFailure => invalidName.failure;
+
+  @override
+  List<Object?> get props => [contentFailure, age, invalidName];
+
+  @override
+  StringifyMode get stringifyMode => StringifyMode.always;
+}
+```
+
+_Example 3 :_ Creating an `InvalidEntityGeneral` using freezed. This also demonstrates the alternative for the situation where we want to have a nullable parameter annotated with both `@invalid` and `@InvalidNull`.
+
+```dart
+@freezed
+class InvalidPerson extends InvalidEntityGeneral<PersonGeneralFailure>
+    with _$InvalidPerson {
+  const factory InvalidPerson({
+    required Age age,
+    required InvalidName? invalidName,
+  }) = _InvalidPerson;
+
+  const InvalidPerson._();
+
+  @override
+  PersonGeneralFailure get generalFailure => optionOf(invalidName).match(
+      (some) => PersonGeneralFailure.hasName(invalidName: some),
+      () => const PersonGeneralFailure.noName());
+}
+
+@freezed
+class PersonGeneralFailure extends GeneralFailure with _$PersonGeneralFailure {
+  const factory PersonGeneralFailure.hasName(
+      {required InvalidName invalidName}) = _HasName;
+  const factory PersonGeneralFailure.noName() = _NoName;
+}
+```
+
+In this example, it's true that we aren't replicating the exact behaviour of having both an `InvalidEntityGeneral` and an `InvalidEntityContent`, but it's a good compromise since we know `invalidName` will always cause a failure.
+
 ---
 
 # Testers
@@ -679,13 +874,13 @@ For example, for a 'Name' ValueObject :
 void main() {
   // (1)
   final nameTester = NameTester();
-  
+
   // (2)
   nameTester.makeIsValidTestGroup(tests: [
     TestIsValidValue('Josh'),
     TestIsValidValue('Avi'),
   ]);
-  
+
   // (3)
   nameTester.makeIsInvalidTestGroup(tests: [
     TestIsInvalidValue('', const NameValueFailure.empty(failedValue: '')),
@@ -699,50 +894,50 @@ Each of the functions **(2)** and **(3)** create a group of tests. The group's `
 
 1. Providing it in the `Tester`'s arguments
 
-	```dart
-	final nameTester = NameTester(
-		isValidGroupDescription: 'Should be valid when given a valid name',
-		isInvalidGroupDescription: 'Should be invalid when given an invalid name',
-	);
-	```
+   ```dart
+   final nameTester = NameTester(
+   	isValidGroupDescription: 'Should be valid when given a valid name',
+   	isInvalidGroupDescription: 'Should be invalid when given an invalid name',
+   );
+   ```
 
-2. Providing it in the function itself. *This takes priority over a description set in the `Tester`'s arguments.*
+2. Providing it in the function itself. _This takes priority over a description set in the `Tester`'s arguments._
 
-	```dart
-	nameTester.makeIsValidTestGroup(
-		tests: ...,
-		description: 'Should be valid when given a valid name',
-	);
-	```
+   ```dart
+   nameTester.makeIsValidTestGroup(
+   	tests: ...,
+   	description: 'Should be valid when given a valid name',
+   );
+   ```
 
-Each test's description is also automatically created. It usually contains the String representation of the modddel SUT *(`modddel.toString()`)*. To keep these descriptions tidy, this String's length is limited to `maxSutDescriptionLength`, beyond which it is ellipsized. This `maxSutDescriptionLength` defaults to `100`, but it can be modified by :
+Each test's description is also automatically created. It usually contains the String representation of the modddel SUT _(`modddel.toString()`)_. To keep these descriptions tidy, this String's length is limited to `maxSutDescriptionLength`, beyond which it is ellipsized. This `maxSutDescriptionLength` defaults to `100`, but it can be modified by :
 
 1. Providing it in the modddel annotation :
 
-	```dart
-	@ModddelAnnotation(maxSutDescriptionLength: 50)
-	```
+   ```dart
+   @ModddelAnnotation(maxSutDescriptionLength: 50)
+   ```
 
-2. Providing it in the `Tester`'s arguments. *This takes priority over `maxSutDescriptionLength` set in the `@ModddelAnnotation`.*
+2. Providing it in the `Tester`'s arguments. _This takes priority over `maxSutDescriptionLength` set in the `@ModddelAnnotation`._
 
-	```dart
-	final nameTester = NameTester(
-		maxSutDescriptionLength: 50,
-	);
-	```
+   ```dart
+   final nameTester = NameTester(
+   	maxSutDescriptionLength: 50,
+   );
+   ```
 
-3. Providing it in the function itself. *This takes priority over `maxSutDescriptionLength` set in the `Tester`'s arguments.*
+3. Providing it in the function itself. _This takes priority over `maxSutDescriptionLength` set in the `Tester`'s arguments._
 
-	```dart
-	nameTester.makeIsValidTestGroup(
-		tests: ...,
-		maxSutDescriptionLength: 50,
-	);
-	```
+   ```dart
+   nameTester.makeIsValidTestGroup(
+   	tests: ...,
+   	maxSutDescriptionLength: 50,
+   );
+   ```
 
 > **NB 1:** This "ellipsisation" can be disabled by setting `maxSutDescriptionLength` value to `TesterUtils.noEllipsis` (Which equals `-1`).
 >
-> **NB 2:** The group description of `makeIsSanitizedTestGroup` contains two Strings (the input + the sanitizedValue), so each one's length is limited to *the half* of `maxSutDescriptionLength`. This is so that all group descriptions have comparable lengths.
+> **NB 2:** The group description of `makeIsSanitizedTestGroup` contains two Strings (the input + the sanitizedValue), so each one's length is limited to _the half_ of `maxSutDescriptionLength`. This is so that all group descriptions have comparable lengths.
 
 A test's description can be modified by providing the `customDescription` parameter.
 
@@ -779,210 +974,210 @@ nameTester.makeIsNotSanitizedTestGroup(
 
 ```json
 {
-		"Value Object": {
-		"prefix": "valueobject",
-		"body": [
-			"@modddel",
-			"class ${1} extends ValueObject<${2}, ${1}ValueFailure, Invalid${1}, Valid${1}>",
-			"    with $${1} {",
-			"  factory ${1}(${2} input) {",
-			"    return $${1}._create(input);",
-			"  }",
-			"",
-			"  const ${1}._();",
-			"",
-			"  @override",
-			"  Option<${1}ValueFailure> validateValue(${2} input) {",
-			"    //TODO Implement validateValue",
-			"    return none();",
-			"  }",
-			"}"
-		],
-		"description": "Value Object"
-	},
-	"Value Failure": {
-		"prefix": "valuefailure",
-		"body": [
-			"@freezed",
-			"class ${1}ValueFailure extends ValueFailure<${2}> with _$${1}ValueFailure {",
-			"  const factory ${1}ValueFailure.${3}({",
-			"    required ${2} failedValue,${4}",
-			"  }) = _${3/(^.)/${1:/upcase}/};",
-			"}"
-		],
-		"description": "Value Failure"
-	},
-	"Value Failure Union Case": {
-		"prefix": "valuefailurecase",
-		"body": [
-			"const factory ${1}ValueFailure.${3}({",
-			"  required ${2} failedValue,${4}",
-			"}) = _${3/(^.)/${1:/upcase}/};",
-		],
-		"description": "Value Failure Union Case"
-	},
-	"Simple Entity": {
-		"prefix": "simpleentity",
-		"body": [
-			"@modddel",
-			"class ${1} extends SimpleEntity<Invalid${1}Content, Valid${1}> with $${1} {",
-			"  factory ${1}({",
-			"    ${2}",
-			"  }) {",
-			"    return $${1}._create(",
-			"      ${3}",
-			"    );",
-			"  }",
-			"",
-			"  const ${1}._();",
-			"",
-			"}",
-		],
-		"description": "Simple Entity"
-	},
-	"List Entity": {
-		"prefix": "listentity",
-		"body": [
-			"@modddel",
-			"class ${1} extends ListEntity<Invalid${1}Content, Valid${1}> with $${1} {",
-			"  factory ${1}(KtList<${2}> list) {",
-			"    return $${1}._create(list);",
-			"  }",
-			"",
-			"  const ${1}._();",
-			"",
-			"}",
-		],
-		"description": "List Entity"
-	},
-	"Sized List Entity": {
-		"prefix": "sizedlistentity",
-		"body": [
-			"@modddel",
-			"class ${1} extends SizedListEntity<${1}SizeFailure, Invalid${1},",
-			" Valid${1}> with $${1} {",
-			"  factory ${1}(KtList<${2}> list) {",
-			"    return $${1}._create(list);",
-			"  }",
-			"",
-			"  const ${1}._();",
-			"",
-			"  @override",
-			"  Option<${1}SizeFailure> validateSize(int listSize) {",
-			"    //TODO Implement validateSize",
-			"    return none();",
-			"  }",
-			"}",
-		],
-		"description": "Sized List Entity"
-	},
-	"General Entity": {
-		"prefix": "generalentity",
-		"body": [
-			"@modddel",
-			"class ${1} extends GeneralEntity<${1}GeneralFailure,",
-			"    Invalid${1}, Valid${1}> with $${1} {",
-			"  factory ${1}({",
-			"    ${2}",
-			"  }) {",
-			"    return $${1}._create(",
-			"      ${3}",
-			"    );",
-			"  }",
-			"",
-			"  const ${1}._();",
-			"",
-			"  @override",
-			"  Option<${1}GeneralFailure> validateGeneral(Valid${1} valid) {",
-			"    //TODO Implement validateGeneral",
-			"    return none();",
-			"  }",
-			"}",
-		],
-		"description": "General Entity"
-	},
-	"List General Entity": {
-		"prefix": "listgeneralentity",
-		"body": [
-			"@modddel",
-			"class ${1} extends ListGeneralEntity<${1}GeneralFailure,",
-			"    Invalid${1}, Valid${1}> with $${1} {",
-			"  factory ${1}(KtList<${2}> list) {",
-			"    return $${1}._create(list);",
-			"  }",
-			"",
-			"  const ${1}._();",
-			"",
-			"  @override",
-			"  Option<${1}GeneralFailure> validateGeneral(Valid${1} valid) {",
-			"    //TODO Implement validateGeneral",
-			"    return none();",
-			"  }",
-			"}",
-		],
-		"description": "List General Entity"
-	},
-	"Sized List General Entity": {
-		"prefix": "sizedlistgeneralentity",
-		"body": [
-			"@modddel",
-			"class ${1} extends SizedListGeneralEntity<${1}SizeFailure, ${1}GeneralFailure,",
-			" Invalid${1}, Valid${1}> with $${1} {",
-			"  factory ${1}(KtList<${2}> list) {",
-			"    return $${1}._create(list);",
-			"  }",
-			"",
-			"  const ${1}._();",
-			"",
-			"  @override",
-			"  Option<${1}SizeFailure> validateSize(int listSize) {",
-			"    //TODO Implement validateSize",
-			"    return none();",
-			"  }",
-			"",
-			"  @override",
-			"  Option<${1}GeneralFailure> validateGeneral(Valid${1} valid) {",
-			"    //TODO Implement validateGeneral",
-			"    return none();",
-			"  }",
-			"}",
-		],
-		"description": "Sized List General Entity"
-	},
-	"General Failure": {
-		"prefix": "generalfailure",
-		"body": [
-			"@freezed",
-			"class ${1}GeneralFailure extends GeneralFailure with _$${1}GeneralFailure {",
-			"  const factory ${1}GeneralFailure.${2}(${3}) = _${2/(^.)/${1:/upcase}/};",
-			"}"
-		],
-		"description": "General Failure"
-	},
-	"General Failure Union Case": {
-		"prefix": "generalfailurecase",
-		"body": [
-			"const factory ${1}GeneralFailure.${2}(${3}) = _${2/(^.)/${1:/upcase}/};",
-		],
-		"description": "General Failure Union Case"
-	},
-	"Size Failure": {
-		"prefix": "sizefailure",
-		"body": [
-			"@freezed",
-			"class ${1}SizeFailure extends SizeFailure with _$${1}SizeFailure {",
-			"  const factory ${1}SizeFailure.${2}(${3}) = _${2/(^.)/${1:/upcase}/};",
-			"}"
-		],
-		"description": "Size Failure"
-	},
-	"Size Failure Union Case": {
-		"prefix": "sizefailurecase",
-		"body": [
-			"const factory ${1}SizeFailure.${2}(${3}) = _${2/(^.)/${1:/upcase}/};",
-		],
-		"description": "Size Failure Union Case"
-	},
+  "Value Object": {
+    "prefix": "valueobject",
+    "body": [
+      "@modddel",
+      "class ${1} extends ValueObject<${2}, ${1}ValueFailure, Invalid${1}, Valid${1}>",
+      "    with $${1} {",
+      "  factory ${1}(${2} input) {",
+      "    return $${1}._create(input);",
+      "  }",
+      "",
+      "  const ${1}._();",
+      "",
+      "  @override",
+      "  Option<${1}ValueFailure> validateValue(${2} input) {",
+      "    //TODO Implement validateValue",
+      "    return none();",
+      "  }",
+      "}"
+    ],
+    "description": "Value Object"
+  },
+  "Value Failure": {
+    "prefix": "valuefailure",
+    "body": [
+      "@freezed",
+      "class ${1}ValueFailure extends ValueFailure<${2}> with _$${1}ValueFailure {",
+      "  const factory ${1}ValueFailure.${3}({",
+      "    required ${2} failedValue,${4}",
+      "  }) = _${3/(^.)/${1:/upcase}/};",
+      "}"
+    ],
+    "description": "Value Failure"
+  },
+  "Value Failure Union Case": {
+    "prefix": "valuefailurecase",
+    "body": [
+      "const factory ${1}ValueFailure.${3}({",
+      "  required ${2} failedValue,${4}",
+      "}) = _${3/(^.)/${1:/upcase}/};"
+    ],
+    "description": "Value Failure Union Case"
+  },
+  "Simple Entity": {
+    "prefix": "simpleentity",
+    "body": [
+      "@modddel",
+      "class ${1} extends SimpleEntity<Invalid${1}Content, Valid${1}> with $${1} {",
+      "  factory ${1}({",
+      "    ${2}",
+      "  }) {",
+      "    return $${1}._create(",
+      "      ${3}",
+      "    );",
+      "  }",
+      "",
+      "  const ${1}._();",
+      "",
+      "}"
+    ],
+    "description": "Simple Entity"
+  },
+  "List Entity": {
+    "prefix": "listentity",
+    "body": [
+      "@modddel",
+      "class ${1} extends ListEntity<Invalid${1}Content, Valid${1}> with $${1} {",
+      "  factory ${1}(KtList<${2}> list) {",
+      "    return $${1}._create(list);",
+      "  }",
+      "",
+      "  const ${1}._();",
+      "",
+      "}"
+    ],
+    "description": "List Entity"
+  },
+  "Sized List Entity": {
+    "prefix": "sizedlistentity",
+    "body": [
+      "@modddel",
+      "class ${1} extends SizedListEntity<${1}SizeFailure, Invalid${1},",
+      " Valid${1}> with $${1} {",
+      "  factory ${1}(KtList<${2}> list) {",
+      "    return $${1}._create(list);",
+      "  }",
+      "",
+      "  const ${1}._();",
+      "",
+      "  @override",
+      "  Option<${1}SizeFailure> validateSize(int listSize) {",
+      "    //TODO Implement validateSize",
+      "    return none();",
+      "  }",
+      "}"
+    ],
+    "description": "Sized List Entity"
+  },
+  "General Entity": {
+    "prefix": "generalentity",
+    "body": [
+      "@modddel",
+      "class ${1} extends GeneralEntity<${1}GeneralFailure,",
+      "    Invalid${1}, Valid${1}> with $${1} {",
+      "  factory ${1}({",
+      "    ${2}",
+      "  }) {",
+      "    return $${1}._create(",
+      "      ${3}",
+      "    );",
+      "  }",
+      "",
+      "  const ${1}._();",
+      "",
+      "  @override",
+      "  Option<${1}GeneralFailure> validateGeneral(Valid${1} valid) {",
+      "    //TODO Implement validateGeneral",
+      "    return none();",
+      "  }",
+      "}"
+    ],
+    "description": "General Entity"
+  },
+  "List General Entity": {
+    "prefix": "listgeneralentity",
+    "body": [
+      "@modddel",
+      "class ${1} extends ListGeneralEntity<${1}GeneralFailure,",
+      "    Invalid${1}, Valid${1}> with $${1} {",
+      "  factory ${1}(KtList<${2}> list) {",
+      "    return $${1}._create(list);",
+      "  }",
+      "",
+      "  const ${1}._();",
+      "",
+      "  @override",
+      "  Option<${1}GeneralFailure> validateGeneral(Valid${1} valid) {",
+      "    //TODO Implement validateGeneral",
+      "    return none();",
+      "  }",
+      "}"
+    ],
+    "description": "List General Entity"
+  },
+  "Sized List General Entity": {
+    "prefix": "sizedlistgeneralentity",
+    "body": [
+      "@modddel",
+      "class ${1} extends SizedListGeneralEntity<${1}SizeFailure, ${1}GeneralFailure,",
+      " Invalid${1}, Valid${1}> with $${1} {",
+      "  factory ${1}(KtList<${2}> list) {",
+      "    return $${1}._create(list);",
+      "  }",
+      "",
+      "  const ${1}._();",
+      "",
+      "  @override",
+      "  Option<${1}SizeFailure> validateSize(int listSize) {",
+      "    //TODO Implement validateSize",
+      "    return none();",
+      "  }",
+      "",
+      "  @override",
+      "  Option<${1}GeneralFailure> validateGeneral(Valid${1} valid) {",
+      "    //TODO Implement validateGeneral",
+      "    return none();",
+      "  }",
+      "}"
+    ],
+    "description": "Sized List General Entity"
+  },
+  "General Failure": {
+    "prefix": "generalfailure",
+    "body": [
+      "@freezed",
+      "class ${1}GeneralFailure extends GeneralFailure with _$${1}GeneralFailure {",
+      "  const factory ${1}GeneralFailure.${2}(${3}) = _${2/(^.)/${1:/upcase}/};",
+      "}"
+    ],
+    "description": "General Failure"
+  },
+  "General Failure Union Case": {
+    "prefix": "generalfailurecase",
+    "body": [
+      "const factory ${1}GeneralFailure.${2}(${3}) = _${2/(^.)/${1:/upcase}/};"
+    ],
+    "description": "General Failure Union Case"
+  },
+  "Size Failure": {
+    "prefix": "sizefailure",
+    "body": [
+      "@freezed",
+      "class ${1}SizeFailure extends SizeFailure with _$${1}SizeFailure {",
+      "  const factory ${1}SizeFailure.${2}(${3}) = _${2/(^.)/${1:/upcase}/};",
+      "}"
+    ],
+    "description": "Size Failure"
+  },
+  "Size Failure Union Case": {
+    "prefix": "sizefailurecase",
+    "body": [
+      "const factory ${1}SizeFailure.${2}(${3}) = _${2/(^.)/${1:/upcase}/};"
+    ],
+    "description": "Size Failure Union Case"
+  }
 }
 ```
 

--- a/modddels_annotations/README.md
+++ b/modddels_annotations/README.md
@@ -46,6 +46,7 @@ The different states a Modddel can have are represented with **Union Cases Class
 	- [SizedListGeneralEntity](#sizedlistgeneralentity)
 		- [Usage](#usage-6)
 	- [Additionnal remarks](#additionnal-remarks)
+		- [TypeName annotation](#typename-annotation)
 		- [Optional and Nullable types](#optional-and-nullable-types)
 		- [Modddels that are always valid](#modddels-that-are-always-valid)
 		- [List getter](#list-getter)
@@ -611,6 +612,32 @@ When creating a SizedListGeneralEntity, the validation is made in this order :
 ---
 
 ## Additionnal remarks
+
+### TypeName annotation
+
+The types of the constructor parameters of `SimpleEntity` and `GeneralEntity` need to be defined at the time of generation. If the type does not exist at the time of generation (which is usually the case when the type class itself is generated), you should manually provide it using the `@TypeName` annotation.
+
+Example :
+
+```dart
+@modddel
+class Person extends SimpleEntity<InvalidPersonContent, ValidPerson>
+    with $Person {
+  factory Person({
+    required Age age,
+    @TypeName('ValidName') @valid required ValidName validName,
+  }) {
+    return $Person._create(
+	  age: age,
+      validName: validName,
+	);
+  }
+
+  const Person._();
+}
+```
+
+Here, `ValidName` is a generated class so it's not defined during the generation. So we provided the type using `@TypeName('ValidName')`.
 
 ### Optional and Nullable types
 

--- a/modddels_annotations/README.md
+++ b/modddels_annotations/README.md
@@ -779,7 +779,7 @@ nameTester.makeIsNotSanitizedTestGroup(
 
 ```json
 {
-	"Value Object": {
+		"Value Object": {
 		"prefix": "valueobject",
 		"body": [
 			"@modddel",
@@ -806,8 +806,8 @@ nameTester.makeIsNotSanitizedTestGroup(
 			"@freezed",
 			"class ${1}ValueFailure extends ValueFailure<${2}> with _$${1}ValueFailure {",
 			"  const factory ${1}ValueFailure.${3}({",
-			"    required ${2} failedValue,${5}",
-			"  }) = _${4};",
+			"    required ${2} failedValue,${4}",
+			"  }) = _${3/(^.)/${1:/upcase}/};",
 			"}"
 		],
 		"description": "Value Failure"
@@ -816,8 +816,8 @@ nameTester.makeIsNotSanitizedTestGroup(
 		"prefix": "valuefailurecase",
 		"body": [
 			"const factory ${1}ValueFailure.${3}({",
-			"  required ${2} failedValue,${5}",
-			"}) = _${4};",
+			"  required ${2} failedValue,${4}",
+			"}) = _${3/(^.)/${1:/upcase}/};",
 		],
 		"description": "Value Failure Union Case"
 	},
@@ -954,7 +954,7 @@ nameTester.makeIsNotSanitizedTestGroup(
 		"body": [
 			"@freezed",
 			"class ${1}GeneralFailure extends GeneralFailure with _$${1}GeneralFailure {",
-			"  const factory ${1}GeneralFailure.${2}(${4}) = _${3};",
+			"  const factory ${1}GeneralFailure.${2}(${3}) = _${2/(^.)/${1:/upcase}/};",
 			"}"
 		],
 		"description": "General Failure"
@@ -962,7 +962,7 @@ nameTester.makeIsNotSanitizedTestGroup(
 	"General Failure Union Case": {
 		"prefix": "generalfailurecase",
 		"body": [
-			"const factory ${1}GeneralFailure.${2}(${4}) = _${3};",
+			"const factory ${1}GeneralFailure.${2}(${3}) = _${2/(^.)/${1:/upcase}/};",
 		],
 		"description": "General Failure Union Case"
 	},
@@ -971,7 +971,7 @@ nameTester.makeIsNotSanitizedTestGroup(
 		"body": [
 			"@freezed",
 			"class ${1}SizeFailure extends SizeFailure with _$${1}SizeFailure {",
-			"  const factory ${1}SizeFailure.${2}(${4}) = _${3};",
+			"  const factory ${1}SizeFailure.${2}(${3}) = _${2/(^.)/${1:/upcase}/};",
 			"}"
 		],
 		"description": "Size Failure"
@@ -979,7 +979,7 @@ nameTester.makeIsNotSanitizedTestGroup(
 	"Size Failure Union Case": {
 		"prefix": "sizefailurecase",
 		"body": [
-			"const factory ${1}SizeFailure.${2}(${4}) = _${3};",
+			"const factory ${1}SizeFailure.${2}(${3}) = _${2/(^.)/${1:/upcase}/};",
 		],
 		"description": "Size Failure Union Case"
 	},

--- a/modddels_annotations/README.md
+++ b/modddels_annotations/README.md
@@ -43,7 +43,7 @@ The different states a Modddel can have are represented with **Union Cases Class
 		- [Fields getters](#fields-getters)
 		- [The `valid` annotation](#the-valid-annotation-1)
 		- [The `invalid` annotation](#the-invalid-annotation-1)
-		- [The `InvalidNull` annotation](#the-invalidnull-annotation)
+		- [The `NullFailure` annotation](#the-nullfailure-annotation)
 	- [ListGeneralEntity](#listgeneralentity)
 		- [Usage](#usage-5)
 	- [SizedListGeneralEntity](#sizedlistgeneralentity)
@@ -230,7 +230,7 @@ When creating a SimpleEntity, the validation is made in this order :
 
 When a `SimpleEntity` contains a nullable modddel, when it is null, it is considered valid during the "Content Validation" step.
 
-If you want a nullable modddel to make the Entity invalid when it's null, consider using a `GeneralEntity` and annotating the parameter with the [`@InvalidNull` annotation.](#the-invalidnull-annotation)
+If you want a nullable modddel to make the Entity invalid when it's null, consider using a `GeneralEntity` and annotating the parameter with the [`@NullFailure` annotation.](#the-nullfailure-annotation)
 
 ### The `valid` annotation
 
@@ -474,12 +474,12 @@ If you want to use both `@invalid` and `@withGetter` annotation, you can use the
 
 > **NB :** For the same reasons as for `SimpleEntity` [(mentioned here)](#the-invalid-annotation), the `invalid` annotation can only be used on nullable parameters.
 
-### The `InvalidNull` annotation
+### The `NullFailure` annotation
 
 When a `GeneralEntity` contains a nullable modddel, when it is null, it is considered valid during the "Content Validation" step. If you want the `GeneralEntity` to be invalid when that parameter is null, you could :
 
 - Verify if the parameter is null in the `validateGeneral` method, and if so, return a `GeneralFailure`. **(Not recommended)**
-- Use the `@InvalidNull` annotation with the String of the `GeneralFailure`. This is the recommended way, since it has the benefit of making the field non-nullable in the `ValidEntity`.
+- Use the `@NullFailure` annotation with the String of the `GeneralFailure`. This is the recommended way, since it has the benefit of making the field non-nullable in the `ValidEntity`.
 
 Example :
 
@@ -487,7 +487,7 @@ Example :
 class FullName extends GeneralEntity<FullNameGeneralFailure, InvalidFullName,
     ValidFullName> with $FullName {
   factory FullName({
-    @InvalidNull('const FullNameGeneralFailure.incomplete()')
+    @NullFailure('const FullNameGeneralFailure.incomplete()')
         required Name? lastName,
     ...
   }) {
@@ -497,9 +497,9 @@ class FullName extends GeneralEntity<FullNameGeneralFailure, InvalidFullName,
 
 Here, if the field `lastName` is null, then the `FullName` entity will be an `InvalidEntityGeneral`, with as a general failure `FullNameGeneralFailure.incomplete()`. The field `lastName` in `ValidFullName` is non-nullable.
 
-> **NB 1:** This validation step of nullable fields marked with the `@InvalidNull` annotation occurs just before the `validateGeneral` method is called. So the entity passed in the `validateGeneral` method will have those fields non-nullable.
+> **NB 1:** This validation step of nullable fields marked with the `@NullFailure` annotation occurs just before the `validateGeneral` method is called. So the entity passed in the `validateGeneral` method will have those fields non-nullable.
 >
-> **NB 2:** The `@InvalidNull` annotation can be used with any other annotation, except `@invalid`. That's because a nullable parameter annotated with both `@invalid` and `@InvalidNull` will cause the `GeneralEntity` to never be valid, while fundamentally, an Entity can either be valid or invalid.
+> **NB 2:** The `@NullFailure` annotation can be used with any other annotation, except `@invalid`. That's because a nullable parameter annotated with both `@invalid` and `@NullFailure` will cause the `GeneralEntity` to never be valid, while fundamentally, an Entity can either be valid or invalid.
 >
 > For an alternative to this specific case, see [the related section in "Special Cases".](#modddels-that-are-always-invalid).
 
@@ -772,7 +772,7 @@ Sometimes you may need to create a modddel that is always invalid. For example :
 
 - A ValueObject that is always invalid and holds a Failure.
 - A `SimpleEntity` or `GeneralEntity` with a non-nullable `@invalid` parameter [(See remark)](#the-invalid-annotation)
-- A `GeneralEntity` with a nullable parameter annotated with both `@invalid` and `@InvalidNull` [(See remark)](#the-invalidnull-annotation)
+- A `GeneralEntity` with a nullable parameter annotated with both `@invalid` and `@NullFailure` [(See remark)](#the-nullfailure-annotation)
 
 However, modddels by definition have both a valid and invalid state, so this isn't allowed.
 
@@ -833,7 +833,7 @@ class InvalidPersonContent2 extends InvalidEntityContent
 }
 ```
 
-_Example 3 :_ Creating an `InvalidEntityGeneral` using freezed. This also demonstrates the alternative for the situation where we want to have a nullable parameter annotated with both `@invalid` and `@InvalidNull`.
+_Example 3 :_ Creating an `InvalidEntityGeneral` using freezed. This also demonstrates the alternative for the situation where we want to have a nullable parameter annotated with both `@invalid` and `@NullFailure`.
 
 ```dart
 @freezed

--- a/modddels_annotations/lib/modddels.dart
+++ b/modddels_annotations/lib/modddels.dart
@@ -22,7 +22,7 @@ export 'src/modddels/annotations.dart'
         validWithGetter,
         InvalidWithGetterAnnotation,
         invalidWithGetter,
-        InvalidNull,
+        NullFailure,
         TypeName;
 
 export 'src/modddels/value_objects/value_object.dart'

--- a/modddels_annotations/lib/modddels.dart
+++ b/modddels_annotations/lib/modddels.dart
@@ -14,10 +14,14 @@ export 'src/modddels/annotations.dart'
         modddel,
         ValidAnnotation,
         valid,
+        InvalidAnnotation,
+        invalid,
         WithGetterAnnotation,
         withGetter,
         ValidWithGetterAnnotation,
         validWithGetter,
+        InvalidWithGetterAnnotation,
+        invalidWithGetter,
         InvalidNull,
         TypeName;
 

--- a/modddels_annotations/lib/modddels.dart
+++ b/modddels_annotations/lib/modddels.dart
@@ -6,7 +6,7 @@ library modddels;
 
 export 'src/modddels/errors.dart' show UnreachableError;
 export 'src/modddels/modddel.dart'
-    show Modddel, ValidModddel, InvalidModddel, Failure;
+    show Modddel, ValidModddel, InvalidModddel, Failure, Stringify;
 export 'src/modddels/annotations.dart'
     show
         StringifyMode,

--- a/modddels_annotations/lib/modddels.dart
+++ b/modddels_annotations/lib/modddels.dart
@@ -18,7 +18,8 @@ export 'src/modddels/annotations.dart'
         withGetter,
         ValidWithGetterAnnotation,
         validWithGetter,
-        InvalidNull;
+        InvalidNull,
+        TypeName;
 
 export 'src/modddels/value_objects/value_object.dart'
     show ValueObject, ValidValueObject, InvalidValueObject, ValueFailure;

--- a/modddels_annotations/lib/src/modddels/annotations.dart
+++ b/modddels_annotations/lib/src/modddels/annotations.dart
@@ -202,7 +202,7 @@ const invalidWithGetter = InvalidWithGetterAnnotation();
 /// class FullName extends GeneralEntity<FullNameGeneralFailure, InvalidFullName,
 ///     ValidFullName> with $FullName {
 ///   factory FullName({
-///     @InvalidNull('const FullNameGeneralFailure.incomplete()')
+///     @NullFailure('const FullNameGeneralFailure.incomplete()')
 ///         required Name? lastName,
 ///     ...
 ///   }) {
@@ -214,8 +214,8 @@ const invalidWithGetter = InvalidWithGetterAnnotation();
 /// `InvalidEntityGeneral`, with as a general failure
 /// `FullNameGeneralFailure.incomplete()`. The field `lastName` in
 /// `ValidFullName` is non-nullable.
-class InvalidNull {
-  const InvalidNull(this.generalFailure);
+class NullFailure {
+  const NullFailure(this.generalFailure);
 
   final String generalFailure;
 }

--- a/modddels_annotations/lib/src/modddels/annotations.dart
+++ b/modddels_annotations/lib/src/modddels/annotations.dart
@@ -2,6 +2,7 @@ import 'package:equatable/equatable.dart';
 import 'package:modddels_annotations/src/modddels/entities/common.dart';
 import 'package:modddels_annotations/src/modddels/entities/general_entity.dart';
 import 'package:modddels_annotations/src/modddels/entities/simple_entity.dart';
+import 'package:modddels_annotations/src/modddels/modddel.dart';
 import 'package:modddels_annotations/src/modddels/value_objects/value_object.dart';
 import 'package:modddels_annotations/src/testers/testers_utils.dart';
 
@@ -66,6 +67,10 @@ class ValidAnnotation {
   const ValidAnnotation();
 }
 
+class InvalidAnnotation {
+  const InvalidAnnotation();
+}
+
 class WithGetterAnnotation {
   const WithGetterAnnotation();
 }
@@ -74,18 +79,23 @@ class ValidWithGetterAnnotation {
   const ValidWithGetterAnnotation();
 }
 
+class InvalidWithGetterAnnotation {
+  const InvalidWithGetterAnnotation();
+}
+
 const modddel = ModddelAnnotation();
 
-/// This annotation can only be used inside a [SimpleEntity] or a [GeneralEntity], in
-/// front of a factory parameter.
+/// This annotation can only be used inside a [SimpleEntity] or a
+/// [GeneralEntity], in front of a factory parameter.
 ///
 /// Use this annotation :
-/// - When you want a a [SimpleEntity] or a [GeneralEntity] to contain a modddel that should be considered as
-///   being valid (so it shouldn't be validated)
+/// - When you want a [SimpleEntity] or a [GeneralEntity] to contain a modddel
+///   that should be considered as being valid (so it shouldn't be validated)
 /// - When a parameter isn't a modddel and should be considered as being valid.
 ///   For example : a [ValidValueObject], a [ValidEntity], a boolean...
 ///
 /// Example :
+///
 /// ```dart
 /// factory FullName({
 ///    required Name firstName,
@@ -95,6 +105,25 @@ const modddel = ModddelAnnotation();
 /// ```
 
 const valid = ValidAnnotation();
+
+/// This annotation can only be used inside a [SimpleEntity] or a
+/// [GeneralEntity], in front of a **nullable** factory parameter.
+///
+/// Use this annotation when you want a [SimpleEntity] or a [GeneralEntity]
+/// to contain an [InvalidModddel] that should be always considered as invalid,
+/// unless it's null.
+///
+/// Example :
+///
+/// ```dart
+/// factory FullName({
+///    required Name firstName,
+///    required Name lastName,
+///    @invalid @TypeName('InvalidName?') required InvalidName? middleName,
+///  }) { ...
+/// ```
+
+const invalid = InvalidAnnotation();
 
 /// This annotation can only be used inside a [GeneralEntity], in front of a
 /// factory parameter.
@@ -109,11 +138,12 @@ const valid = ValidAnnotation();
 /// For example :
 ///
 /// ```dart
-///   final firstName = fullName.firstName; //ERROR : The getter 'firstName'
-///   isn't defined for the type 'FullName'.
+///   final firstName = fullName.firstName;
+///   //ERROR : The getter 'firstName' isn't defined for the type 'FullName'.
 ///
 ///   final firstName = fullName.mapValidity( valid: (valid) => valid.firstName,
-///       invalid: (invalid) => invalid.firstName); //No error.
+///       invalid: (invalid) => invalid.firstName);
+///   //No error.
 /// ```
 ///
 /// That's because the GeneralEntity may have a GeneralFailure, which may be
@@ -124,6 +154,7 @@ const valid = ValidAnnotation();
 ///  example : Having a getter for an "id" field.
 ///
 /// Example :
+///
 /// ```dart
 /// factory FullName({
 ///    @withGetter required UniqueId id,
@@ -136,6 +167,7 @@ const withGetter = WithGetterAnnotation();
 /// Same as specifying both the [valid] and [withGetter] annotations.
 ///
 /// Example :
+///
 /// ```dart
 /// factory FullName({
 ///    @validWithGetter required String id,
@@ -145,6 +177,43 @@ const withGetter = WithGetterAnnotation();
 /// ```
 const validWithGetter = ValidWithGetterAnnotation();
 
+/// Same as specifying both the [invalid] and [withGetter] annotations.
+///
+/// Example :
+/// ```dart
+/// factory FullName({
+///    required Name firstName,
+///    required Name lastName,
+///    @invalidWithGetter @TypeName('InvalidName?') required InvalidName? middleName,
+///  }) { ...
+/// ```
+const invalidWithGetter = InvalidWithGetterAnnotation();
+
+/// This annotation can only be used inside a [GeneralEntity], in front of a
+/// factory parameter.
+///
+/// Use this annotation when you want a [GeneralEntity] to contain a nullable
+/// modddel that, when null, should make the entity invalid and hold a
+/// generalFailure (that you should provide as a String).
+///
+/// Example :
+///
+/// ```dart
+/// class FullName extends GeneralEntity<FullNameGeneralFailure, InvalidFullName,
+///     ValidFullName> with $FullName {
+///   factory FullName({
+///     @InvalidNull('const FullNameGeneralFailure.incomplete()')
+///         required Name? lastName,
+///     ...
+///   }) {
+///     ...
+///
+/// ```
+///
+/// Here, if the field `lastName` is null, then the `FullName` entity will be an
+/// `InvalidEntityGeneral`, with as a general failure
+/// `FullNameGeneralFailure.incomplete()`. The field `lastName` in
+/// `ValidFullName` is non-nullable.
 class InvalidNull {
   const InvalidNull(this.generalFailure);
 

--- a/modddels_annotations/lib/src/modddels/annotations.dart
+++ b/modddels_annotations/lib/src/modddels/annotations.dart
@@ -150,3 +150,36 @@ class InvalidNull {
 
   final String generalFailure;
 }
+
+/// Use this to manually provide the type of a [SimpleEntity] or [GeneralEntity]
+/// constructor parameter.
+///
+/// This is useful when the type does not exist at the time of generation (which
+/// is usually the case when the type class itself is generated).
+///
+/// Example :
+///
+/// ```dart
+/// @modddel
+/// class Person extends SimpleEntity<InvalidPersonContent, ValidPerson>
+///     with $Person {
+///   factory Person({
+///     required Age age,
+///     @TypeName('ValidName') @valid required ValidName validName,
+///   }) {
+///     return $Person._create(
+///       age: age,
+///       validName: validName,
+///     );
+///   }
+///
+///   const Person._();
+/// }
+/// ```
+///
+/// Here, `ValidName` is a generated class so it's not defined during the
+/// generation. So we provided the type using `@TypeName('ValidName')`.
+class TypeName {
+  const TypeName(this.typeName);
+  final String typeName;
+}

--- a/modddels_annotations/lib/src/modddels/entities/common.dart
+++ b/modddels_annotations/lib/src/modddels/entities/common.dart
@@ -4,16 +4,22 @@ import 'package:modddels_annotations/src/modddels/modddel.dart';
 
 /// A [ValidEntity] is the valid union-case of an entity. It holds all the valid
 /// versions of the modddels contained inside the entity.
-abstract class ValidEntity extends ValidModddel {}
+abstract class ValidEntity extends ValidModddel {
+  const ValidEntity();
+}
 
 /// A [InvalidEntity] is the invalid union-case of an entity. It can be further
 /// subdivided into other specific invalid union-cases, depending on the
 /// failured (the failed validation).
-abstract class InvalidEntity extends InvalidModddel {}
+abstract class InvalidEntity extends InvalidModddel {
+  const InvalidEntity();
+}
 
 /// An [InvalidEntitySize] is an [InvalidEntity] made invalid the size of the
 /// list of modddels it is holding is invalid. It holds the [SizeFailure].
 abstract class InvalidEntitySize<F extends SizeFailure> extends InvalidEntity {
+  const InvalidEntitySize();
+
   F get sizeFailure;
 
   // Note to self : We override `failure` for easier usage when we directly
@@ -26,6 +32,8 @@ abstract class InvalidEntitySize<F extends SizeFailure> extends InvalidEntity {
 /// its modddels is invalid. It holds the [Failure] of the first encountered
 /// invalid modddel.
 abstract class InvalidEntityContent extends InvalidEntity {
+  const InvalidEntityContent();
+
   /// The failure of the first encountered invalid modddel inside this entity.
   Failure get contentFailure;
 
@@ -40,6 +48,8 @@ abstract class InvalidEntityContent extends InvalidEntity {
 /// valid, but the entity is invalid as a whole.
 abstract class InvalidEntityGeneral<F extends GeneralFailure>
     extends InvalidEntity {
+  const InvalidEntityGeneral();
+
   F get generalFailure;
 
   // Note to self : We override `failure` for easier usage when we directly
@@ -50,7 +60,11 @@ abstract class InvalidEntityGeneral<F extends GeneralFailure>
 
 /// A [SizeFailure] is a [Failure] of the size of a [SizedListEntity] or
 /// [SizedListGeneralEntity].
-abstract class SizeFailure extends Failure {}
+abstract class SizeFailure extends Failure {
+  const SizeFailure();
+}
 
 /// A [GeneralFailure] is a [Failure] of the entity as a whole.
-abstract class GeneralFailure extends Failure {}
+abstract class GeneralFailure extends Failure {
+  const GeneralFailure();
+}

--- a/modddels_annotations/lib/src/modddels/entities/common.dart
+++ b/modddels_annotations/lib/src/modddels/entities/common.dart
@@ -7,14 +7,19 @@ import 'package:modddels_annotations/src/modddels/modddel.dart';
 abstract class ValidEntity extends ValidModddel {}
 
 /// A [InvalidEntity] is the invalid union-case of an entity. It can be further
-/// subdivided into other specific invalid union-cases, depending on the failured
-/// (the failed validation).
+/// subdivided into other specific invalid union-cases, depending on the
+/// failured (the failed validation).
 abstract class InvalidEntity extends InvalidModddel {}
 
 /// An [InvalidEntitySize] is an [InvalidEntity] made invalid the size of the
 /// list of modddels it is holding is invalid. It holds the [SizeFailure].
 abstract class InvalidEntitySize<F extends SizeFailure> extends InvalidEntity {
   F get sizeFailure;
+
+  // Note to self : We override `failure` for easier usage when we directly
+  // extend this class.
+  @override
+  Failure get failure => sizeFailure;
 }
 
 /// An [InvalidEntityContent] is an [InvalidEntity] made invalid because one of
@@ -23,15 +28,24 @@ abstract class InvalidEntitySize<F extends SizeFailure> extends InvalidEntity {
 abstract class InvalidEntityContent extends InvalidEntity {
   /// The failure of the first encountered invalid modddel inside this entity.
   Failure get contentFailure;
+
+  // Note to self : We override `failure` for easier usage when we directly
+  // extend this class.
+  @override
+  Failure get failure => contentFailure;
 }
 
-/// An [InvalidEntityGeneral] is an [InvalidEntity] caused by a [GeneralFailure].
-/// All the modddels inside this [InvalidEntityGeneral] are valid, but the entity
-/// is invalid as a whole.
-
+/// An [InvalidEntityGeneral] is an [InvalidEntity] caused by a
+/// [GeneralFailure]. All the modddels inside this [InvalidEntityGeneral] are
+/// valid, but the entity is invalid as a whole.
 abstract class InvalidEntityGeneral<F extends GeneralFailure>
     extends InvalidEntity {
   F get generalFailure;
+
+  // Note to self : We override `failure` for easier usage when we directly
+  // extend this class.
+  @override
+  Failure get failure => generalFailure;
 }
 
 /// A [SizeFailure] is a [Failure] of the size of a [SizedListEntity] or

--- a/modddels_annotations/lib/src/modddels/modddel.dart
+++ b/modddels_annotations/lib/src/modddels/modddel.dart
@@ -108,6 +108,8 @@ abstract class InvalidModddel {
   Failure get failure;
 }
 
+/// This is a convenience mixin to automatically override [Equatable.stringify]
+/// based on the desired [stringifyMode].
 mixin Stringify {
   /// See [Equatable.stringify]
   bool? get stringify {

--- a/modddels_annotations/lib/src/modddels/modddel.dart
+++ b/modddels_annotations/lib/src/modddels/modddel.dart
@@ -58,8 +58,9 @@ abstract class Modddel<I extends InvalidModddel, V extends ValidModddel>
 /// Example :
 ///
 /// ```dart
-/// class ValidName extends ValidValueObject<String> {
-///   ValidName(this.value);
+/// class ValidName extends ValidValueObject<String>
+///     with EquatableMixin, Stringify {
+///   const ValidName(this.value);
 ///
 ///   @override
 ///   final String value;
@@ -71,11 +72,9 @@ abstract class Modddel<I extends InvalidModddel, V extends ValidModddel>
 ///   StringifyMode get stringifyMode => StringifyMode.always;
 /// }
 /// ```
-
-// Note to self : This extends [Equatable] and mixins [Stringify] for the
-// use-case where we directly extend this class's subclasses such as
-// [ValidValueObject].
-abstract class ValidModddel extends Equatable with Stringify {}
+abstract class ValidModddel {
+  const ValidModddel();
+}
 
 /// This is the base class for the "Invalid" union-case of a modddel.
 ///
@@ -88,9 +87,10 @@ abstract class ValidModddel extends Equatable with Stringify {}
 /// Example :
 ///
 /// ```dart
-/// class InvalidName extends InvalidValueObject<String,NameValueFailure>{
+/// class InvalidName extends InvalidValueObject<String,NameValueFailure>
+///     with EquatableMixin, Stringify {
 ///
-///   InvalidName(this.valueFailure);
+///   const InvalidName(this.valueFailure);
 ///
 ///   @override
 ///   final NameValueFailure valueFailure;
@@ -102,11 +102,9 @@ abstract class ValidModddel extends Equatable with Stringify {}
 ///   StringifyMode get stringifyMode => StringifyMode.always;
 /// }
 /// ```
+abstract class InvalidModddel {
+  const InvalidModddel();
 
-// Note to self : This extends [Equatable] and mixins [Stringify] for the
-// use-case where we directly extend this class's subclasses such as
-// [InvalidValueObject].
-abstract class InvalidModddel extends Equatable with Stringify {
   Failure get failure;
 }
 

--- a/modddels_annotations/lib/src/modddels/modddel.dart
+++ b/modddels_annotations/lib/src/modddels/modddel.dart
@@ -50,9 +50,10 @@ abstract class Modddel<I extends InvalidModddel, V extends ValidModddel>
 
 /// This is the base class for the "Valid" union-case of a modddel.
 ///
-/// NB : This class's subclasses such as [ValidValueObject] are used as
-/// interfaces in the generated "Valid" classes. However, you can directly
-/// extend them if you want to have a modddel that is always valid.
+/// NB : This class's subclasses, which are : [ValidValueObject] -
+/// [ValidEntity], are used as interfaces in the generated "Valid" classes.
+/// However, you can directly extend them if you want to have a modddel that is
+/// always valid.
 ///
 /// Example :
 ///
@@ -78,9 +79,11 @@ abstract class ValidModddel extends Equatable with Stringify {}
 
 /// This is the base class for the "Invalid" union-case of a modddel.
 ///
-/// NB : This class's subclasses such as [InvalidValueObject] are used as
-/// interfaces in the generated "Invalid" classes. However, you can directly
-/// extend them if you want to have a modddel that is always invalid.
+/// NB : This class's subclasses, which are : [InvalidValueObject] -
+/// [InvalidEntity] - [InvalidEntitySize] - [InvalidEntityContent] -
+/// [InvalidEntityGeneral], are used as interfaces in the generated "Invalid"
+/// classes. However, you can directly extend them if you want to have a modddel
+/// that is always invalid.
 ///
 /// Example :
 ///

--- a/modddels_annotations/lib/src/modddels/modddel.dart
+++ b/modddels_annotations/lib/src/modddels/modddel.dart
@@ -130,4 +130,6 @@ mixin Stringify {
 /// The base class for all the possible failures a [Modddel] can have.
 ///
 /// For example : [ValueFailure], [GeneralFailure], [SizeFailure]...
-abstract class Failure {}
+abstract class Failure {
+  const Failure();
+}

--- a/modddels_annotations/lib/src/modddels/value_objects/value_object.dart
+++ b/modddels_annotations/lib/src/modddels/value_objects/value_object.dart
@@ -27,6 +27,8 @@ abstract class ValueObject<
 /// A [ValidValueObject] is the "valid" union-case of a [ValueObject]. It holds
 /// the validated [value].
 abstract class ValidValueObject<T> extends ValidModddel {
+  const ValidValueObject();
+
   /// The validated value.
   T get value;
 }
@@ -35,6 +37,8 @@ abstract class ValidValueObject<T> extends ValidModddel {
 /// It holds the [ValueFailure] that made it invalid.
 abstract class InvalidValueObject<T, F extends ValueFailure<T>>
     extends InvalidModddel {
+  const InvalidValueObject();
+
   /// The [ValueFailure] that made this [ValueObject] invalid.
   F get valueFailure;
 
@@ -46,6 +50,8 @@ abstract class InvalidValueObject<T, F extends ValueFailure<T>>
 
 /// A [ValueFailure] is a [Failure] caused by an invalid value of a [ValueObject]
 abstract class ValueFailure<T> extends Failure {
+  const ValueFailure();
+
   /// The invalid value of the [ValueObject].
   ///
   /// NB : All the freezed subclasses union-cases should have in their constructor the

--- a/modddels_annotations/lib/src/modddels/value_objects/value_object.dart
+++ b/modddels_annotations/lib/src/modddels/value_objects/value_object.dart
@@ -2,13 +2,13 @@ import 'package:fpdart/fpdart.dart';
 import 'package:modddels_annotations/src/modddels/modddel.dart';
 
 /// A [ValueObject] is a [Modddel] that holds a single value, which is validated
-/// via the `validateValue` method. This method returns `some` [ValueFailure] if the
-/// value is invalid, otherwise returns `none`.
+/// via the `validateValue` method. This method returns `some` [ValueFailure] if
+/// the value is invalid, otherwise returns `none`.
 ///
 /// When creating the ValueObject, the validation is made in this order :
 ///
-/// 1. **Value Validation** : If the value is invalid, this [ValueObject] becomes an
-///    [InvalidValueObject] that holds the [ValueFailure].
+/// 1. **Value Validation** : If the value is invalid, this [ValueObject]
+///    becomes an [InvalidValueObject] that holds the [ValueFailure].
 /// 2. **→ Validations passed** : This [ValueObject] is valid, and becomes a
 ///    [ValidValueObject], from which you can access the valid value.
 abstract class ValueObject<
@@ -19,8 +19,8 @@ abstract class ValueObject<
   const ValueObject();
 
   /// Validates the value that will be held inside this [ValueObject]. This
-  /// method should return `some` [ValueFailure] if the value is invalid, otherwise
-  /// it should return `none`.
+  /// method should return `some` [ValueFailure] if the value is invalid,
+  /// otherwise it should return `none`.
   Option<F> validateValue(T input);
 }
 
@@ -31,12 +31,17 @@ abstract class ValidValueObject<T> extends ValidModddel {
   T get value;
 }
 
-/// An [InvalidValueObject] is is the "invalid" union-case of a [ValueObject]. It
-/// holds the [ValueFailure] that made it invalid.
+/// An [InvalidValueObject] is is the "invalid" union-case of a [ValueObject].
+/// It holds the [ValueFailure] that made it invalid.
 abstract class InvalidValueObject<T, F extends ValueFailure<T>>
     extends InvalidModddel {
   /// The [ValueFailure] that made this [ValueObject] invalid.
   F get valueFailure;
+
+  // Note to self : We override `failure` for easier usage when we directly
+  // extend this class.
+  @override
+  Failure get failure => valueFailure;
 }
 
 /// A [ValueFailure] is a [Failure] caused by an invalid value of a [ValueObject]

--- a/modddels_generator/lib/src/generators/general_entity_generator.dart
+++ b/modddels_generator/lib/src/generators/general_entity_generator.dart
@@ -75,19 +75,19 @@ class GeneralEntityGenerator {
     }
 
     for (final param in classInfo.namedParameters) {
-      if (param.hasInvalidAnnotation && param.hasInvalidNullAnnotation) {
+      if (param.hasInvalidAnnotation && param.hasNullFailureAnnotation) {
         throw InvalidGenerationSourceError(
-          'The @invalid and @InvalidNull annotations can\'t be used together on the same parameter.',
+          'The @invalid and @NullFailure annotations can\'t be used together on the same parameter.',
           element: param.parameter,
         );
       }
     }
 
     for (final param in classInfo.namedParameters) {
-      if (param.hasInvalidNullAnnotation) {
+      if (param.hasNullFailureAnnotation) {
         if (!param.isNullable) {
           throw InvalidGenerationSourceError(
-            'The @InvalidNull annotation can only be used with nullable parameters.',
+            'The @NullFailure annotation can only be used with nullable parameters.',
             element: param.parameter,
           );
         }
@@ -178,7 +178,7 @@ class GeneralEntityGenerator {
     /// verifyGeneral function
     classBuffer.writeln('''
     /// This holds a [GeneralFailure] on the Left if :
-    ///  - One of the nullable fields marked with `@InvalidNull` is null
+    ///  - One of the nullable fields marked with `@NullFailure` is null
     ///  - The validateGeneral method returns a [GeneralFailure]
     /// Otherwise, holds the ValidEntity on the Right.
     static Either<${classInfo.generalFailure}, ${classInfo.validEntity}> _verifyGeneral(
@@ -371,15 +371,15 @@ class GeneralEntityGenerator {
 
     /// verifyNullables method
     classBuffer.writeln('''
-    /// If one of the nullable fields marked with `@InvalidNull` is null, this
+    /// If one of the nullable fields marked with `@NullFailure` is null, this
     /// holds a [GeneralFailure] on the Left. Otherwise, holds the ValidEntity on
     /// the Right.
     Either<${classInfo.generalFailure}, ${classInfo.validEntity}> verifyNullables() {
 
-      ${classInfo.namedParameters.where((p) => p.hasInvalidNullAnnotation).map((param) => '''
+      ${classInfo.namedParameters.where((p) => p.hasNullFailureAnnotation).map((param) => '''
       final ${param.name} = this.${param.name};
       if(${param.name} == null) {
-        return left(${param.invalidNullGeneralFailure});
+        return left(${param.nullFailureString});
       }
       
       ''').join()}
@@ -414,7 +414,7 @@ class GeneralEntityGenerator {
       if (param.hasWithGetterAnnotation) {
         classBuffer.writeln('@override');
       }
-      final paramType = param.hasInvalidNullAnnotation
+      final paramType = param.hasNullFailureAnnotation
           ? param.typeWithoutNullabilitySuffix
           : param.type;
 

--- a/modddels_generator/lib/src/generators/general_entity_generator.dart
+++ b/modddels_generator/lib/src/generators/general_entity_generator.dart
@@ -154,15 +154,12 @@ class GeneralEntityGenerator {
 
     /// Getters for fields marked with '@withGetter' (or with '@validWithGetter')
 
-    final getterParameters = classInfo.namedParameters
-        .where((e) => e.hasWithGetterAnnotation == true);
+    final getterParameters =
+        classInfo.namedParameters.where((e) => e.hasWithGetterAnnotation);
 
     for (final param in getterParameters) {
       classBuffer.writeln('''
-      ${param.type} get ${param.name} => mapValidity(
-        valid: (valid) => valid.${param.name},
-        invalid: (invalid) => invalid.${param.name},
-      );
+      ${param.type} get ${param.name} => throw UnimplementedError();
     
       ''');
     }
@@ -364,7 +361,7 @@ class GeneralEntityGenerator {
 
     /// class members
     for (final param in classInfo.namedParameters) {
-      if (param.hasWithGetterAnnotation == true) {
+      if (param.hasWithGetterAnnotation) {
         classBuffer.writeln('@override');
       }
       final paramType = param.hasInvalidNullAnnotation
@@ -418,7 +415,7 @@ class GeneralEntityGenerator {
 
     /// Fields Getters
     for (final param in classInfo.namedParameters) {
-      if (param.hasWithGetterAnnotation == true) {
+      if (param.hasWithGetterAnnotation) {
         classBuffer.writeln('@override');
       }
       classBuffer.writeln('${param.type} get ${param.name};');

--- a/modddels_generator/lib/src/generators/general_entity_generator.dart
+++ b/modddels_generator/lib/src/generators/general_entity_generator.dart
@@ -37,16 +37,18 @@ class GeneralEntityGenerator {
       );
     }
 
-    for (final param in namedParameters) {
+    final classInfo = GeneralEntityClassInfo(className, namedParameters);
+
+    for (final param in classInfo.namedParameters) {
       if (param.type.toString() == 'dynamic') {
         throw InvalidGenerationSourceError(
-          'The named parameters of the factory constructor should have valid types, and should not be dynamic',
-          element: param,
+          'The named parameters of the factory constructor should have valid types, and should not be dynamic.'
+          'Consider using the @TypeName annotation to manually provide the type.',
+          element: param.parameter,
         );
       }
     }
 
-    final classInfo = GeneralEntityClassInfo(className, namedParameters);
 
     for (final param in classInfo.namedParameters) {
       if (param.hasInvalidNullAnnotation) {

--- a/modddels_generator/lib/src/generators/general_entity_generator.dart
+++ b/modddels_generator/lib/src/generators/general_entity_generator.dart
@@ -40,7 +40,7 @@ class GeneralEntityGenerator {
     final classInfo = GeneralEntityClassInfo(className, namedParameters);
 
     for (final param in classInfo.namedParameters) {
-      if (param.type.toString() == 'dynamic') {
+      if (param.type == 'dynamic') {
         throw InvalidGenerationSourceError(
           'The named parameters of the factory constructor should have valid types, and should not be dynamic.'
           'Consider using the @TypeName annotation to manually provide the type.',

--- a/modddels_generator/lib/src/generators/simple_entity_generator.dart
+++ b/modddels_generator/lib/src/generators/simple_entity_generator.dart
@@ -37,16 +37,18 @@ class SimpleEntityGenerator {
       );
     }
 
-    for (final param in namedParameters) {
+    final classInfo = SimpleEntityClassInfo(className, namedParameters);
+
+    for (final param in classInfo.namedParameters) {
       if (param.type.toString() == 'dynamic') {
         throw InvalidGenerationSourceError(
-          'The named parameters of the factory constructor should have valid types, and should not be dynamic',
-          element: param,
+          'The named parameters of the factory constructor should have valid types, and should not be dynamic.'
+          'Consider using the @TypeName annotation to manually provide the type.',
+          element: param.parameter,
         );
       }
     }
 
-    final classInfo = SimpleEntityClassInfo(className, namedParameters);
 
     for (final param in classInfo.namedParameters) {
       if (param.hasWithGetterAnnotation) {

--- a/modddels_generator/lib/src/generators/simple_entity_generator.dart
+++ b/modddels_generator/lib/src/generators/simple_entity_generator.dart
@@ -40,7 +40,7 @@ class SimpleEntityGenerator {
     final classInfo = SimpleEntityClassInfo(className, namedParameters);
 
     for (final param in classInfo.namedParameters) {
-      if (param.type.toString() == 'dynamic') {
+      if (param.type == 'dynamic') {
         throw InvalidGenerationSourceError(
           'The named parameters of the factory constructor should have valid types, and should not be dynamic.'
           'Consider using the @TypeName annotation to manually provide the type.',

--- a/modddels_generator/lib/src/generators/simple_entity_generator.dart
+++ b/modddels_generator/lib/src/generators/simple_entity_generator.dart
@@ -84,9 +84,9 @@ class SimpleEntityGenerator {
     }
 
     for (final param in classInfo.namedParameters) {
-      if (param.hasInvalidNullAnnotation) {
+      if (param.hasNullFailureAnnotation) {
         throw InvalidGenerationSourceError(
-          'The @InvalidNull annotation can only be used with a GeneralEntity.',
+          'The @NullFailure annotation can only be used with a GeneralEntity.',
           element: param.parameter,
         );
       }

--- a/modddels_generator/lib/src/utils.dart
+++ b/modddels_generator/lib/src/utils.dart
@@ -137,7 +137,12 @@ class EntityParameter {
     return type.endsWith('?') ? type : '$type?';
   }
 
-  String get type => parameter.type.toString();
+  String get type => hasTypeNameAnnotation
+      ? _typeNameChecker
+          .firstAnnotationOfExact(parameter)!
+          .getField('typeName')!
+          .toStringValue()!
+      : parameter.type.toString();
 
   String get typeWithoutNullabilitySuffix =>
       type.endsWith('?') ? type.substring(0, type.length - 1) : type;
@@ -175,6 +180,10 @@ class EntityParameter {
   bool get hasInvalidNullAnnotation =>
       _invalidNullChecker.hasAnnotationOfExact(parameter);
 
+  /// True if the parameter has the `@TypeName` annotation.
+  bool get hasTypeNameAnnotation =>
+      _typeNameChecker.hasAnnotationOfExact(parameter);
+
   String get invalidNullGeneralFailure {
     final annotation = _invalidNullChecker.annotationsOfExact(parameter).single;
 
@@ -200,6 +209,8 @@ const _validWithGetterChecker =
     TypeChecker.fromRuntime(ValidWithGetterAnnotation);
 
 const _invalidNullChecker = TypeChecker.fromRuntime(InvalidNull);
+
+const _typeNameChecker = TypeChecker.fromRuntime(TypeName);
 
 extension StringExtension on String {
   String capitalize() {

--- a/modddels_generator/lib/src/utils.dart
+++ b/modddels_generator/lib/src/utils.dart
@@ -160,18 +160,24 @@ class EntityParameter {
 
   bool get isNullable => type.endsWith('?');
 
-  /// True if the parameter has the `@valid` annotation or the `@validWithGetter`
-  /// annotation
+  /// True if the parameter has the `@valid` annotation or the
+  /// `@validWithGetter` annotation
   bool get hasValidAnnotation =>
       _validChecker.hasAnnotationOfExact(parameter) ||
       _validWithGetterChecker.hasAnnotationOfExact(parameter);
 
-  /// True if the parameter has the `@withGetter` annotation or the
-  /// `@validWithGetter` annotation
+  /// True if the parameter has the `@invalid` annotation or the
+  /// `@invalidWithGetter` annotation
+  bool get hasInvalidAnnotation =>
+      _invalidChecker.hasAnnotationOfExact(parameter) ||
+      _invalidWithGetterChecker.hasAnnotationOfExact(parameter);
 
+  /// True if the parameter has the `@withGetter` annotation, the
+  /// `@validWithGetter` annotation, or the `@invalidWithGetter` annotation
   bool get hasWithGetterAnnotation =>
       _withGetterChecker.hasAnnotationOfExact(parameter) ||
-      _validWithGetterChecker.hasAnnotationOfExact(parameter);
+      _validWithGetterChecker.hasAnnotationOfExact(parameter) ||
+      _invalidWithGetterChecker.hasAnnotationOfExact(parameter);
 
   bool get hasInvalidNullAnnotation =>
       _invalidNullChecker.hasAnnotationOfExact(parameter);
@@ -199,10 +205,15 @@ class EntityParameter {
 
 const _validChecker = TypeChecker.fromRuntime(ValidAnnotation);
 
+const _invalidChecker = TypeChecker.fromRuntime(InvalidAnnotation);
+
 const _withGetterChecker = TypeChecker.fromRuntime(WithGetterAnnotation);
 
 const _validWithGetterChecker =
     TypeChecker.fromRuntime(ValidWithGetterAnnotation);
+
+const _invalidWithGetterChecker =
+    TypeChecker.fromRuntime(InvalidWithGetterAnnotation);
 
 const _invalidNullChecker = TypeChecker.fromRuntime(InvalidNull);
 

--- a/modddels_generator/lib/src/utils.dart
+++ b/modddels_generator/lib/src/utils.dart
@@ -1,5 +1,4 @@
 import 'package:analyzer/dart/element/element.dart';
-import 'package:analyzer/dart/element/nullability_suffix.dart';
 
 /// ⚠️ We shouldn't import the testers, because they use the package
 /// 'flutter_test' which in turn imports dart:ui, which is not allowed in a
@@ -157,12 +156,9 @@ class EntityParameter {
 
   String get optionalType => optionalize(type);
 
-  bool get isRequired => parameter.isRequiredNamed;
-
   bool get hasDefaultValue => parameter.hasDefaultValue;
 
-  bool get isNullable =>
-      parameter.type.nullabilitySuffix == NullabilitySuffix.question;
+  bool get isNullable => type.endsWith('?');
 
   /// True if the parameter has the `@valid` annotation or the `@validWithGetter`
   /// annotation

--- a/modddels_generator/lib/src/utils.dart
+++ b/modddels_generator/lib/src/utils.dart
@@ -179,15 +179,23 @@ class EntityParameter {
       _validWithGetterChecker.hasAnnotationOfExact(parameter) ||
       _invalidWithGetterChecker.hasAnnotationOfExact(parameter);
 
-  bool get hasInvalidNullAnnotation =>
-      _invalidNullChecker.hasAnnotationOfExact(parameter);
+  /// True if the parameter has the `@NullFailure` annotation.
+  bool get hasNullFailureAnnotation =>
+      _nullFailureChecker.hasAnnotationOfExact(parameter);
 
   /// True if the parameter has the `@TypeName` annotation.
   bool get hasTypeNameAnnotation =>
       _typeNameChecker.hasAnnotationOfExact(parameter);
 
-  String get invalidNullGeneralFailure {
-    final annotation = _invalidNullChecker.annotationsOfExact(parameter).single;
+  /// Returns the value of the `@NullFailure` annotation's field
+  /// [NullFailure.generalFailure].
+  ///
+  /// This should only be called if this parameter has the `@NullFailure`
+  /// annotation.
+  String get nullFailureString {
+    assert(hasNullFailureAnnotation);
+
+    final annotation = _nullFailureChecker.annotationsOfExact(parameter).single;
 
     final generalFailure =
         annotation.getField('generalFailure')?.toStringValue();
@@ -215,7 +223,7 @@ const _validWithGetterChecker =
 const _invalidWithGetterChecker =
     TypeChecker.fromRuntime(InvalidWithGetterAnnotation);
 
-const _invalidNullChecker = TypeChecker.fromRuntime(InvalidNull);
+const _nullFailureChecker = TypeChecker.fromRuntime(NullFailure);
 
 const _typeNameChecker = TypeChecker.fromRuntime(TypeName);
 


### PR DESCRIPTION
### New features

- Add support to `@TypeName` annotation
- Add support for `@invalid` annotation
- Document and Export Stringify
- Fix #11

### Breaking changes

- Remove Equatable from Valid/InvalidModddel

  Remove Equatable and Stringify mixins from ValidModddel and
InvalidModddel. This is so that the dev can have the freedom to choose
his method of choice for making a dataclass when directly extending
those classes. (Ex : freezed, equatable, manually...)

- Rename InvalidNull to NullFailure (Fix #22)

### Bug fixes and improvements
- Optimize @withGetter codegen

  Getters for fields marked with @withGetter of @validWithGetter
now throw an UnimplementedError, since they are overridden in the Valid
and Invalid classes

- Override failure at the abstract level

  We override `failure` in classes such as InvalidValueObject,
InvalidEntitySize... so that the dev doesn't need to do so when directly
extending thoses classes

- Add const constructors to all modddels
- Improve VsCode snippets

